### PR TITLE
Allow for singular values to be given as either controller or action arguments

### DIFF
--- a/lib/active_link_to.rb
+++ b/lib/active_link_to.rb
@@ -148,8 +148,8 @@ module ActiveLinkTo
     when Regexp
       !request.fullpath.match(options[:when]).blank?
     when Array
-      controllers = options[:when][0]
-      actions     = options[:when][1]
+      controllers = [*options[:when][0]]
+      actions     = [*options[:when][1]]
       (controllers.blank? || controllers.member?(params[:controller])) &&
       (actions.blank? || actions.member?(params[:action]))
     when TrueClass

--- a/test/active_link_to_test.rb
+++ b/test/active_link_to_test.rb
@@ -49,6 +49,20 @@ class ActiveLinkToTest < Test::Unit::TestCase
     assert_equal '<a href="/test">name</a>', out
   end
   
+  
+  def test_matching_controller_action_singular_values
+    request.fullpath = '/test/23'
+    params[:controller], params[:action] = 'tests', 'show'
+    out = active_link_to 'name', '/test/23', :active => { :when => ['tests', ['show', 'edit']]}
+    assert_equal '<a href="/test/23" class="active">name</a>', out
+    out = active_link_to 'name', '/test/23', :active => { :when => [ 'tests' ]}
+    assert_equal '<a href="/test/23" class="active">name</a>', out
+    out = active_link_to 'name', '/test/23', :active => { :when => [nil, 'show']}
+    assert_equal '<a href="/test/23" class="active">name</a>', out
+    out = active_link_to 'name', '/test/23', :active => { :when => ['tests', 'update']}
+    assert_equal '<a href="/test/23">name</a>', out
+  end
+  
   def test_matching_controller_action_touples
     request.fullpath = '/test/23'
     params[:controller], params[:action] = 'tests', 'show'


### PR DESCRIPTION
This just simply wraps strings into an Array so statements like these are possible:

:when => [ 'controller' ]
:when => [ 'controller', 'action' ]
:when => [ 'controller', [ 'action1', 'action2' ]
:when => [ [ 'controller1', 'controller2' ] , 'action' ]

Nothing major, but a nice syntax shortcut.
