### PR TITLE
Add default options

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ You may directly use methods that `active_link_to` relies on.
     active_link_to_class(users_path, :active => :inclusive)
     # => 'active'
 
+## Defaults
+
+You can set default using `ActiveLinkTo.defaults` attribute like this:
+
+    ActiveLinkTo.defaults = { :wrapper_tag => :li }
+
 ### Copyright
 
 Copyright (c) 2009 Oleg Khabarov, The Working Group Inc. See LICENSE for details.

--- a/lib/active_link_to.rb
+++ b/lib/active_link_to.rb
@@ -1,6 +1,14 @@
 module ActiveLinkTo
-  
-  
+  class << self
+    def defaults
+      @defaults ||= {}
+    end
+
+    def defaults=(val)
+      @defaults = val
+    end
+  end
+
   # Wrapper around link_to. Accepts following params:
   #   :active         => Boolean | Symbol | Regex | Controller/Action Pair
   #   :class_active   => String
@@ -20,6 +28,9 @@ module ActiveLinkTo
       options       = args[1] || {}
       html_options  = args[2] || {}
     end
+
+    html_options = ActiveLinkTo.defaults.merge(html_options)
+
     url = url_for(options)
     
     active_options  = { }

--- a/test/active_link_to_test.rb
+++ b/test/active_link_to_test.rb
@@ -139,5 +139,13 @@ class ActiveLinkToTest < Test::Unit::TestCase
     assert_equal '<a href="/root" class="testing active">label</a>', out
     assert_equal ({:class => 'testing', :active => :inclusive }), params
   end
+
+  def test_defaults
+    ActiveLinkTo.defaults = { :wrap_tag => :li }
+    request.fullpath = '/root'
+    link = active_link_to('label', '/root')
+    assert_equal '<li class="active"><a href="/root">label</a></li>', link
+    ActiveLinkTo.defaults = {}
+  end
   
 end


### PR DESCRIPTION
``` ruby
ActiveLinkTo.defaults = { :wrap_tag => :li }

active_link_to 'label', '/root' # => '<li class="active"><a href="/root">label</a></li>'
```
