### PR TITLE
Last slash in url should be ignored if present

### DIFF
--- a/lib/active_link_to.rb
+++ b/lib/active_link_to.rb
@@ -1,6 +1,6 @@
 module ActiveLinkTo
-  
-  
+
+
   # Wrapper around link_to. Accepts following params:
   #   :active         => Boolean | Symbol | Regex | Controller/Action Pair
   #   :class_active   => String
@@ -21,7 +21,7 @@ module ActiveLinkTo
       html_options  = args[2] || {}
     end
     url = url_for(options)
-    
+
     active_options  = { }
     link_options    = { }
     html_options.each do |k, v|
@@ -31,23 +31,23 @@ module ActiveLinkTo
         link_options[k] = v
       end
     end
-    
+
     css_class = link_options.delete(:class).to_s + ' '
     css_class << active_link_to_class(url, active_options)
     css_class.strip!
-    
+
     wrap_tag = active_options[:wrap_tag].present? ? active_options[:wrap_tag] : nil
     link_options[:class] = css_class if css_class.present? && !wrap_tag
-    
+
     link = if active_options[:active_disable] === true && is_active_link?(url, active_options[:active])
       content_tag(:span, name, link_options)
     else
       link_to(name, url, link_options)
     end
-    
+
     wrap_tag ? content_tag(wrap_tag, link, :class => css_class) : link
   end
-  
+
   # Returns css class name. Takes the link's URL and its params
   # Example usage:
   #   active_link_to_class('/root', :class_active => 'on', :class_inactive => 'off')
@@ -59,7 +59,7 @@ module ActiveLinkTo
       options[:class_inactive] || ''
     end
   end
-  
+
   # Returns true or false based on the provided path and condition
   # Possible condition values are:
   #                  Boolean -> true | false
@@ -76,7 +76,7 @@ module ActiveLinkTo
     url = url_for(url).sub(/\?.*/, '') # ignore GET params
     case condition
     when :inclusive, nil
-      !request.fullpath.match(/^#{Regexp.escape(url)}(\/.*|\?.*)?$/).blank?
+      !request.fullpath.match(/^#{Regexp.escape(url).chomp('/')}(\/.*|\?.*)?$/).blank?
     when :exclusive
       !request.fullpath.match(/^#{Regexp.escape(url)}\/?(\?.*)?$/).blank?
     when Regexp
@@ -92,7 +92,7 @@ module ActiveLinkTo
       false
     end
   end
-  
+
 end
 
 ActionView::Base.send :include, ActiveLinkTo

--- a/test/active_link_to_test.rb
+++ b/test/active_link_to_test.rb
@@ -1,71 +1,82 @@
 require 'test_helper'
 
 class ActiveLinkToTest < Test::Unit::TestCase
-  
+
   def test_is_active_link_booleans
     assert is_active_link?('/', true)
     assert !is_active_link?('/', false)
   end
-  
+
   def test_is_active_link_symbol_inclusive
     request.fullpath = '/root'
     assert is_active_link?('/root', :inclusive)
-    
+
     request.fullpath = '/root?param=test'
     assert is_active_link?('/root', :inclusive)
-    
+
     request.fullpath = '/root/child/sub-child'
     assert is_active_link?('/root', :inclusive)
-    
+
     request.fullpath = '/other'
     assert !is_active_link?('/root', :inclusive)
   end
-  
+
   def test_is_active_link_symbol_inclusive_implied
     request.fullpath = '/root/child/sub-child'
     assert is_active_link?('/root')
   end
-  
+
   def test_is_active_link_symbol_inclusive_similar_path
     request.fullpath = '/root/abc'
     assert !is_active_link?('/root/a', :inclusive)
   end
-  
+
+  def test_is_active_link_symbol_inclusive_with_last_slash
+    request.fullpath = '/root/abc'
+    assert is_active_link?('/root/')
+  end
+
+  def test_is_active_link_symbol_inclusive_with_last_slash_and_similar_path
+    request.fullpath = '/root_path'
+    assert !is_active_link?('/root/')
+  end
+
   def test_is_active_link_symbol_inclusive_with_link_params
     request.fullpath = '/root?param=test'
     assert is_active_link?('/root?attr=example')
   end
-  
+
+
   def test_is_active_link_symbol_exclusive
     request.fullpath = '/root'
     assert is_active_link?('/root', :exclusive)
-    
+
     request.fullpath = '/root?param=test'
     assert is_active_link?('/root', :exclusive)
-    
+
     request.fullpath = '/root/child'
     assert !is_active_link?('/root', :exclusive)
   end
-  
+
   def test_is_active_link_symbol_exclusive_with_link_params
     request.fullpath = '/root?param=test'
     assert is_active_link?('/root?attr=example', :exclusive)
   end
-  
+
   def test_is_active_link_regex
     request.fullpath = '/root'
     assert is_active_link?('/', /^\/root/)
-    
+
     request.fullpath = '/root/child'
     assert is_active_link?('/', /^\/r/)
-    
+
     request.fullpath = '/other'
     assert !is_active_link?('/', /^\/r/)
   end
-  
+
   def test_is_active_link_array
     params[:controller], params[:action] = 'controller', 'action'
-    
+
     assert is_active_link?('/', [['controller'], ['action']])
     assert is_active_link?('/', [['controller'], ['action', 'action_b']])
     assert is_active_link?('/', [['controller', 'controller_b'], ['action']])
@@ -73,65 +84,65 @@ class ActiveLinkToTest < Test::Unit::TestCase
     assert is_active_link?('/', ['controller', 'action'])
     assert is_active_link?('/', ['controller', ['action', 'action_b']])
     assert is_active_link?('/', [['controller', 'controller_b'], 'action'])
-    
+
     assert !is_active_link?('/', ['controller_a', 'action'])
     assert !is_active_link?('/', ['controller', 'action_a'])
   end
-  
+
   def test_active_link_to_class
     request.fullpath = '/root'
     assert_equal 'active', active_link_to_class('/root')
     assert_equal 'on', active_link_to_class('/root', :class_active => 'on')
-    
+
     assert_equal '', active_link_to_class('/other')
     assert_equal 'off', active_link_to_class('/other', :class_inactive => 'off')
   end
-  
+
   def test_active_link_to
     request.fullpath = '/root'
     link = active_link_to('label', '/root')
     assert_equal '<a href="/root" class="active">label</a>', link
-    
+
     link = active_link_to('label', '/other')
     assert_equal '<a href="/other">label</a>', link
   end
-  
+
   def test_active_link_to_with_existing_class
     request.fullpath = '/root'
     link = active_link_to('label', '/root', :class => 'current')
     assert_equal '<a href="/root" class="current active">label</a>', link
-    
+
     link = active_link_to('label', '/other', :class => 'current')
     assert_equal '<a href="/other" class="current">label</a>', link
   end
-  
+
   def test_active_link_to_with_custom_classes
     request.fullpath = '/root'
     link = active_link_to('label', '/root', :class_active => 'on')
     assert_equal '<a href="/root" class="on">label</a>', link
-    
+
     link = active_link_to('label', '/other', :class_inactive => 'off')
     assert_equal '<a href="/other" class="off">label</a>', link
   end
-  
+
   def test_active_link_to_with_wrap_tag
     request.fullpath = '/root'
     link = active_link_to('label', '/root', :wrap_tag => :li)
     assert_equal '<li class="active"><a href="/root">label</a></li>', link
-    
+
     link = active_link_to('label', '/root', :wrap_tag => :li, :active_disable => true)
     assert_equal '<li class="active"><span>label</span></li>', link
-    
+
     link = active_link_to('label', '/root', :wrap_tag => :li, :class => 'testing')
     assert_equal '<li class="testing active"><a href="/root">label</a></li>', link
   end
-  
+
   def test_active_link_to_with_active_disable
     request.fullpath = '/root'
     link = active_link_to('label', '/root', :active_disable => true)
     assert_equal '<span class="active">label</span>', link
   end
-  
+
   def test_should_not_modify_passed_params
     request.fullpath = '/root'
     params = { :class => 'testing', :active => :inclusive }
@@ -139,5 +150,5 @@ class ActiveLinkToTest < Test::Unit::TestCase
     assert_equal '<a href="/root" class="testing active">label</a>', out
     assert_equal ({:class => 'testing', :active => :inclusive }), params
   end
-  
+
 end


### PR DESCRIPTION
When you mount engine in Rails its root_path has trailing slash. But inclusive is_active_link? enforces additional slash after url, so it results in double slash requirement.

E.g. when we are mounting Forem engine to "/forum" path

```
forem.root_path # => "/forum/"

request.fullpath = "/forum/"
is_active_link?(forem.root_path) # => true, GOOD

request.fullpath = "/forum/mytopic"
is_active_link?(forem.root_path) # => false, BAD

request.fullpath = "/forum//mytopic"
is_active_link?(forem.root_path) # => true, BAD
```
