### PR TITLE
Don't send the wrap tag a class attribute if it's blank

### DIFF
--- a/lib/active_link_to/active_link_to.rb
+++ b/lib/active_link_to/active_link_to.rb
@@ -44,7 +44,7 @@ module ActiveLinkTo
       link_to(name, url, link_options)
     end
 
-    wrap_tag ? content_tag(wrap_tag, link, :class => css_class) : link
+    wrap_tag ? content_tag(wrap_tag, link, :class => (css_class if css_class.present?)) : link
   end
 
   # Returns css class name. Takes the link's URL and its params

--- a/test/active_link_to_test.rb
+++ b/test/active_link_to_test.rb
@@ -150,4 +150,12 @@ class ActiveLinkToTest < Test::Unit::TestCase
     assert_equal ({:class => 'testing', :active => :inclusive }), params
   end
 
+  def test_no_empty_class_attribute
+    request.fullpath = '/root'
+    link = active_link_to('label', '/root', :wrap_tag => :li)
+    assert_equal '<li class="active"><a class="active" href="/root">label</a></li>', link
+
+    link = active_link_to('label', '/other', :wrap_tag => :li)
+    assert_equal '<li><a href="/other">label</a></li>', link
+  end
 end


### PR DESCRIPTION
It was creating wrap tag elements like `<li class="">` for inactive links. Test is included and passes.
