### PR TITLE
split wrap_tag_css

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,31 @@ active_link_to 'Users', '/users', :active => :inclusive
 # => <a href="/users" class="active">Users</a>
 ```
 
+## Wrapper
+
+Use `:wrap_tag` and `:wrap_tag_class` options to add a wrapper to the active link.
+
+For example,
+
+```ruby
+active_link_to members_path, :wrap_tag => :li, :wrap_tag_class => "menu-item", :class => "menu-item-label", :active => :exclusive do %>
+  "Employees"
+end
+```
+
+generates:
+
+```html
+<li class="menu-item active">
+  <a class="menu-item-label" href="/members">
+    Employees
+  </a>
+</li>
+```
+
+Please note that the `active` class is added to the wrapper, instead of the link.
+
+
 ## Active Options
 Here's a list of available options that can be used as the `:active` value
 

--- a/lib/active_link_to/active_link_to.rb
+++ b/lib/active_link_to/active_link_to.rb
@@ -24,19 +24,25 @@ module ActiveLinkTo
     active_options  = { }
     link_options    = { }
     html_options.each do |k, v|
-      if [:active, :class_active, :class_inactive, :active_disable, :wrap_tag, :wrap_tag_css].member?(k)
+      if [:active, :class_active, :class_inactive, :active_disable, :wrap_tag, :wrap_tag_class].member?(k)
         active_options[k] = v
       else
         link_options[k] = v
       end
     end
 
-    css_class = link_options.delete(:class).to_s + ' '
-    css_class << active_link_to_class(url, active_options)
-    css_class.strip!
+    css_class = "#{link_options.delete(:class).to_s} "
 
     wrap_tag = active_options[:wrap_tag]
-    wrap_tag_css = active_options[:wrap_tag_css]
+    wrap_tag_css_class = "#{active_options[:wrap_tag_class]} "
+
+    if wrap_tag.present?
+      wrap_tag_css_class << active_link_to_class(url, active_options)
+      wrap_tag_css_class.strip!
+    else
+      css_class << active_link_to_class(url, active_options)
+      css_class.strip!
+    end
 
     link_options[:class] = css_class
 
@@ -46,7 +52,7 @@ module ActiveLinkTo
       link_to(name, url, link_options)
     end
 
-    wrap_tag ? content_tag(wrap_tag, link, :class =>  wrap_tag_css ) : link
+    wrap_tag ? content_tag(wrap_tag, link, :class => wrap_tag_css_class ) : link
  
   end
 

--- a/lib/active_link_to/active_link_to.rb
+++ b/lib/active_link_to/active_link_to.rb
@@ -24,7 +24,7 @@ module ActiveLinkTo
     active_options  = { }
     link_options    = { }
     html_options.each do |k, v|
-      if [:active, :class_active, :class_inactive, :active_disable, :wrap_tag].member?(k)
+      if [:active, :class_active, :class_inactive, :active_disable, :wrap_tag, :wrap_tag_css].member?(k)
         active_options[k] = v
       else
         link_options[k] = v
@@ -35,16 +35,19 @@ module ActiveLinkTo
     css_class << active_link_to_class(url, active_options)
     css_class.strip!
 
-    wrap_tag = active_options[:wrap_tag].present? ? active_options[:wrap_tag] : nil
-    link_options[:class] = css_class if css_class.present?
+    wrap_tag = active_options[:wrap_tag]
+    wrap_tag_css = active_options[:wrap_tag_css]
 
-    link = if active_options[:active_disable] === true && is_active_link?(url, active_options[:active])
+    link_options[:class] = css_class
+
+    link = if active_options[:active_disable].present? && is_active_link?(url, active_options[:active])
       content_tag(:span, name, link_options)
     else
       link_to(name, url, link_options)
     end
 
-    wrap_tag ? content_tag(wrap_tag, link, :class => (css_class if css_class.present?)) : link
+    wrap_tag ? content_tag(wrap_tag, link, :class =>  wrap_tag_css ) : link
+ 
   end
 
   # Returns css class name. Takes the link's URL and its params


### PR DESCRIPTION
separate wrap_tag_css from link css

```

<%= active_link_to dashboard_path, :active => :exclusive, :class => "menu-item-label", :wrap_tag => :li, :wrap_tag_class => "menu-item" do %>
  <i class="kbm kbm-dashboard"> </i> Dashboard
<% end %>

```
