### PR TITLE
Add additional class to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If you are constructing navigation menu it might be helpful to wrap links in ano
 
 ```ruby
 active_link_to 'Users', users_path, :wrap_tag => :li
-# => <li class="active"><a href="/users">Users</a></li>
+# => <li class="active"><a href="/users" class="active">Users</a></li>
 ```
     
 ## Helper Methods


### PR DESCRIPTION
When `:wrap_tag => :li` is used the `active` class gets applied to the `<li>` as well as the `<a>` within it. This updates the docs to reflect this.