### PR TITLE
Allow `:active => :exact` for exact matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ When installing for Rails 3 applications add this to the Gemfile: `gem 'active_l
 For older Rails apps add `config.gem 'active_link_to'` in config/environment.rb and run `rake gems:install`. Or just checkout this repo into /vendor/plugins directory.
 
 ## Super Simple Example
-Here's a link that will have a class attached if it happens to be rendered 
+Here's a link that will have a class attached if it happens to be rendered
 on page with path `/users` or any child of that page, like `/users/123`
 
 ```ruby
@@ -27,7 +27,7 @@ Here's a list of available options that can be used as the `:active` value
 
 ```
 * Boolean                 -> true | false
-* Symbol                  -> :exclusive | :inclusive
+* Symbol                  -> :exclusive | :inclusive | :exact
 * Regex                   -> /regex/
 * Controller/Action Pair  -> [[:controller], [:action_a, :action_b]]
 ```
@@ -39,8 +39,8 @@ already, so let's try something more fun.
 
 We want to highlight a link that matches immediate url, but not the children
 nodes. Most commonly used for 'home' links.
-   
-```ruby 
+
+```ruby
 # For URL: /users will be active
 active_link_to 'Users', users_path, :active => :exclusive
 # => <a href="/users" class="active">Users</a>
@@ -51,18 +51,25 @@ active_link_to 'Users', users_path, :active => :exclusive
 active_link_to 'Users', users_path, :active => :exclusive
 # => <a href="/users">Users</a>
 ```
-    
+
 If we need to set link to be active based on some regular expression, we can do
 that as well. Let's try to activate links urls of which begin with 'use':
 
 ```ruby
 active_link_to 'Users', users_path, :active => /^\/use/
 ```
-    
+
+If we need to set link to be active based on an exact match, we can do
+that as well:
+
+```ruby
+active_link_to 'Users', users_path, :active => :exact
+```
+
 What if we need to mark link active for all URLs that match a particular controller,
 or action, or both? Or any number of those at the same time? Sure, why not:
-   
-```ruby 
+
+```ruby
 # For matching multiple controllers and actions:
 active_link_to 'User Edit', edit_user_path(@user), :active => [['people', 'news'], ['show', 'edit']]
 
@@ -72,13 +79,13 @@ active_link_to 'User Edit', edit_user_path(@user), :active => [['people', 'news'
 # for matching all controllers for a particular action
 active_link_to 'User Edit', edit_user_path(@user), :active => [[], ['edit']]
 ```
-    
+
 Sometimes it should be as easy as giving link true or false value:
 
 ```ruby
 active_link_to 'Users', users_path, :active => true
 ```
-    
+
 ## More Options
 You can specify active and inactive css classes for links:
 
@@ -89,7 +96,7 @@ active_link_to 'Users', users_path, :class_active => 'enabled'
 active_link_to 'News', news_path, :class_inactive => 'disabled'
 # => <a href="/news" class="disabled">News</a>
 ```
-    
+
 Sometimes you want to replace link tag with a span if it's active:
 
 ```ruby
@@ -103,19 +110,19 @@ If you are constructing navigation menu it might be helpful to wrap links in ano
 active_link_to 'Users', users_path, :wrap_tag => :li
 # => <li class="active"><a href="/users">Users</a></li>
 ```
-    
+
 ## Helper Methods
-You may directly use methods that `active_link_to` relies on. 
+You may directly use methods that `active_link_to` relies on.
 
 `is_active_link?` will return true or false based on the URL and value of the `:active` parameter:
-    
+
 ```ruby
 is_active_link?(users_path, :inclusive)
 # => true
 ```
-    
+
 `active_link_to_class` will return the css class:
-    
+
 ```
 active_link_to_class(users_path, :active => :inclusive)
 # => 'active'

--- a/lib/active_link_to/active_link_to.rb
+++ b/lib/active_link_to/active_link_to.rb
@@ -1,5 +1,5 @@
 module ActiveLinkTo
-  
+
   # Wrapper around link_to. Accepts following params:
   #   :active         => Boolean | Symbol | Regex | Controller/Action Pair
   #   :class_active   => String
@@ -72,12 +72,15 @@ module ActiveLinkTo
   #   is_active_link?('/root', ['users', ['show', 'edit']])
   #
   def is_active_link?(url, condition = nil)
+    original_url = url
     url = url_for(url).sub(/\?.*/, '') # ignore GET params
     case condition
     when :inclusive, nil
       !request.fullpath.match(/^#{Regexp.escape(url).chomp('/')}(\/.*|\?.*)?$/).blank?
     when :exclusive
       !request.fullpath.match(/^#{Regexp.escape(url)}\/?(\?.*)?$/).blank?
+    when :exact
+      request.fullpath == original_url
     when Regexp
       !request.fullpath.match(condition).blank?
     when Array

--- a/test/active_link_to_test.rb
+++ b/test/active_link_to_test.rb
@@ -114,7 +114,7 @@ class ActiveLinkToTest < MiniTest::Test
   def test_active_link_to
     request.fullpath = '/root'
     link = active_link_to('label', '/root')
-    assert_equal '<a href="/root" class="active">label</a>', link
+    assert_equal '<a class="active" href="/root">label</a>', link
 
     link = active_link_to('label', '/other')
     assert_equal '<a href="/other">label</a>', link
@@ -123,31 +123,31 @@ class ActiveLinkToTest < MiniTest::Test
   def test_active_link_to_with_existing_class
     request.fullpath = '/root'
     link = active_link_to('label', '/root', :class => 'current')
-    assert_equal '<a href="/root" class="current active">label</a>', link
+    assert_equal '<a class="current active" href="/root">label</a>', link
 
     link = active_link_to('label', '/other', :class => 'current')
-    assert_equal '<a href="/other" class="current">label</a>', link
+    assert_equal '<a class="current" href="/other">label</a>', link
   end
 
   def test_active_link_to_with_custom_classes
     request.fullpath = '/root'
     link = active_link_to('label', '/root', :class_active => 'on')
-    assert_equal '<a href="/root" class="on">label</a>', link
+    assert_equal '<a class="on" href="/root">label</a>', link
 
     link = active_link_to('label', '/other', :class_inactive => 'off')
-    assert_equal '<a href="/other" class="off">label</a>', link
+    assert_equal '<a class="off" href="/other">label</a>', link
   end
 
   def test_active_link_to_with_wrap_tag
     request.fullpath = '/root'
     link = active_link_to('label', '/root', :wrap_tag => :li)
-    assert_equal '<li class="active"><a href="/root" class="active">label</a></li>', link
+    assert_equal '<li class="active"><a class="active" href="/root">label</a></li>', link
 
     link = active_link_to('label', '/root', :wrap_tag => :li, :active_disable => true)
     assert_equal '<li class="active"><span class="active">label</span></li>', link
 
     link = active_link_to('label', '/root', :wrap_tag => :li, :class => 'testing')
-    assert_equal '<li class="testing active"><a href="/root" class="testing active">label</a></li>', link
+    assert_equal '<li class="testing active"><a class="testing active" href="/root">label</a></li>', link
   end
 
   def test_active_link_to_with_active_disable
@@ -160,14 +160,14 @@ class ActiveLinkToTest < MiniTest::Test
     request.fullpath = '/root'
     params = { :class => 'testing', :active => :inclusive }
     out = active_link_to 'label', '/root', params
-    assert_equal '<a href="/root" class="testing active">label</a>', out
+    assert_equal '<a class="testing active" href="/root">label</a>', out
     assert_equal ({:class => 'testing', :active => :inclusive }), params
   end
 
   def test_no_empty_class_attribute
     request.fullpath = '/root'
     link = active_link_to('label', '/root', :wrap_tag => :li)
-    assert_equal '<li class="active"><a href="/root" class="active">label</a></li>', link
+    assert_equal '<li class="active"><a class="active" href="/root">label</a></li>', link
 
     link = active_link_to('label', '/other', :wrap_tag => :li)
     assert_equal '<li><a href="/other">label</a></li>', link

--- a/test/active_link_to_test.rb
+++ b/test/active_link_to_test.rb
@@ -1,7 +1,7 @@
 require_relative 'test_helper'
 
 class ActiveLinkToTest < MiniTest::Test
-  
+
   def test_is_active_link_booleans_test
     assert is_active_link?('/', true)
     assert !is_active_link?('/', false)
@@ -60,6 +60,20 @@ class ActiveLinkToTest < MiniTest::Test
   def test_is_active_link_symbol_exclusive_with_link_params
     request.fullpath = '/root?param=test'
     assert is_active_link?('/root?attr=example', :exclusive)
+  end
+
+  def test_is_active_link_symbol_exact
+    request.fullpath = '/root?param=test'
+    assert is_active_link?('/root?param=test', :exact)
+
+    request.fullpath = '/root?param=test'
+    refute is_active_link?('/root?param=exact', :exact)
+
+    request.fullpath = '/root'
+    refute is_active_link?('/root?param=test', :exact)
+
+    request.fullpath = '/root?param=test'
+    refute is_active_link?('/root', :exact)
   end
 
   def test_is_active_link_regex


### PR DESCRIPTION
If we only want to apply the `active` class on a perfect match (e.g. recognizing
the difference between `/users` and `/users?all=true`, we can specify `:active
=> :exact`