### PR TITLE
Use request.original_fullpath instead of request.fullpath

### DIFF
--- a/lib/active_link_to/active_link_to.rb
+++ b/lib/active_link_to/active_link_to.rb
@@ -1,5 +1,5 @@
 module ActiveLinkTo
-  
+
   # Wrapper around link_to. Accepts following params:
   #   :active         => Boolean | Symbol | Regex | Controller/Action Pair
   #   :class_active   => String
@@ -73,13 +73,14 @@ module ActiveLinkTo
   #
   def is_active_link?(url, condition = nil)
     url = url_for(url).sub(/\?.*/, '') # ignore GET params
+    original_fullpath = request.original_fullpath.sub(/\?.*/, '')
     case condition
     when :inclusive, nil
-      !request.fullpath.match(/^#{Regexp.escape(url).chomp('/')}(\/.*|\?.*)?$/).blank?
+      !original_fullpath.match(/^#{Regexp.escape(url).chomp('/')}(\/.*|\?.*)?$/).blank?
     when :exclusive
-      !request.fullpath.match(/^#{Regexp.escape(url)}\/?(\?.*)?$/).blank?
+      !original_fullpath.match(/^#{Regexp.escape(url)}\/?(\?.*)?$/).blank?
     when Regexp
-      !request.fullpath.match(condition).blank?
+      !original_fullpath.match(condition).blank?
     when Array
       controllers = [*condition[0]]
       actions     = [*condition[1]]


### PR DESCRIPTION
When i've a locale in my url, active_link_to doesn't match the url. If i use request.original_fullpath it works.
