### PR TITLE
Add ability to specify a specific pair of controller and action

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ active_link_to 'Users', '/users', :active => :inclusive
 Here's a list of available options that can be used as the `:active` value
 
 ```
-* Boolean                 -> true | false
-* Symbol                  -> :exclusive | :inclusive | :exact
-* Regex                   -> /regex/
-* Controller/Action Pair  -> [[:controller], [:action_a, :action_b]]
+* Boolean                          -> true | false
+* Symbol                           -> :exclusive | :inclusive | :exact
+* Regex                            -> /regex/
+* Controller/Action Pair           -> [[:controller], [:action_a, :action_b]]
+* Controller/Specific Action Pair  -> [controller: :action_a, controller_b: :action_b]
 ```
 
 ## More Examples
@@ -74,6 +75,9 @@ or action, or both? Or any number of those at the same time? Sure, why not:
 ```ruby
 # For matching multiple controllers and actions:
 active_link_to 'User Edit', edit_user_path(@user), :active => [['people', 'news'], ['show', 'edit']]
+
+# For matching specific controllers and actions:
+active_link_to 'User Edit', edit_user_path(@user), :active => [people: :show, news: :edit]
 
 # for matching all actions under given controllers:
 active_link_to 'User Edit', edit_user_path(@user), :active => [['people', 'news'], []]

--- a/lib/active_link_to/active_link_to.rb
+++ b/lib/active_link_to/active_link_to.rb
@@ -89,7 +89,10 @@ module ActiveLinkTo
       controllers = [*condition[0]]
       actions     = [*condition[1]]
       (controllers.blank? || controllers.member?(params[:controller])) &&
-      (actions.blank? || actions.member?(params[:action]))
+      (actions.blank? || actions.member?(params[:action])) ||
+      controllers.any? do |controller, action|
+        params[:controller] == controller.to_s && params[:action] == action.to_s
+      end
     when TrueClass
       true
     when FalseClass

--- a/test/active_link_to_test.rb
+++ b/test/active_link_to_test.rb
@@ -102,6 +102,22 @@ class ActiveLinkToTest < MiniTest::Test
     assert !is_active_link?('/', ['controller', 'action_a'])
   end
 
+  def test_is_active_link_array_with_hash
+    params[:controller], params[:action] = 'controller', 'action'
+
+    assert is_active_link?('/', [controller: :action])
+    assert is_active_link?('/', ['controller' => 'action'])
+
+    refute is_active_link?('/', [controller_b: :action])
+    refute is_active_link?('/', [controller: :action_b])
+    refute is_active_link?('/', [controller_b: :action_b])
+
+    params[:controller], params[:action] = 'controller_b', 'action_b'
+
+    assert is_active_link?('/', [controller: :action, controller_b: :action_b])
+  end
+
+
   def test_is_active_link_hash
     params[:a] = 1
 


### PR DESCRIPTION
Hi,

With the actual behavior it is not possible to define specific actions to match
on a controller if we send the option as `[['controller', 'controller_b'],
['action', 'action_b']]` this will match `controller#action`,
`controller#action_b`, `controller_b#action` and `controller_b#action_b`.

This PR adds the ability to match a specific controller and action using the following
syntax `[controller: :action, controller_b: :action_b]` this will match
`controller#action` and `controller_b#action_b` and does not match
`controller#action_b` and `controller_b#action`.

I hope you enjoy :smile: 
