### PR TITLE
fix error raised by is_active_link on invalid URL

### DIFF
--- a/lib/active_link_to/active_link_to.rb
+++ b/lib/active_link_to/active_link_to.rb
@@ -75,7 +75,7 @@ module ActiveLinkTo
   #
   def is_active_link?(url, condition = nil)
     original_url = url
-    url = URI::parse(url).path
+    url = URI::parse(url).path.to_s
     case condition
     when :inclusive, nil
       !request.fullpath.match(/^#{Regexp.escape(url).chomp('/')}(\/.*|\?.*)?$/).blank?


### PR DESCRIPTION
Fixing error raised on invalid URL (e.g. "javascript:;")

TypeError - no implicit conversion of nil into String:
  active_link_to (1.0.3) lib/active_link_to/active_link_to.rb:81:in `is_active_link?'