### PR TITLE
added wrap_class

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,14 @@ If you are constructing navigation menu it might be helpful to wrap links in ano
 
 ```ruby
 active_link_to 'Users', users_path, :wrap_tag => :li
-# => <li class="active"><a href="/users" class="active">Users</a></li>
+# => <li class="active"><a href="/users">Users</a></li>
+```
+
+You can specify css classes for the `wrap_tag`:
+
+```ruby
+active_link_to 'Users', users_path, :wrap_tag => :li, :wrap_class => 'nav-item'
+# => <li class="nav-item active"><a href="/users">Users</a></li>
 ```
 
 ## Helper Methods

--- a/lib/active_link_to/active_link_to.rb
+++ b/lib/active_link_to/active_link_to.rb
@@ -24,7 +24,7 @@ module ActiveLinkTo
     active_options  = { }
     link_options    = { }
     html_options.each do |k, v|
-      if [:active, :class_active, :class_inactive, :active_disable, :wrap_tag].member?(k)
+      if [:active, :class_active, :class_inactive, :active_disable, :wrap_tag, :wrap_class].member?(k)
         active_options[k] = v
       else
         link_options[k] = v
@@ -32,10 +32,18 @@ module ActiveLinkTo
     end
 
     css_class = link_options.delete(:class).to_s + ' '
-    css_class << active_link_to_class(url, active_options)
-    css_class.strip!
 
     wrap_tag = active_options[:wrap_tag].present? ? active_options[:wrap_tag] : nil
+    wrap_class = active_options[:wrap_class].present? ? active_options[:wrap_class] + ' ' : ''
+
+    if wrap_tag.present?
+      wrap_class << active_link_to_class(url, active_options)
+      wrap_class.strip!
+    else
+      css_class << active_link_to_class(url, active_options)
+      css_class.strip!
+    end
+
     link_options[:class] = css_class if css_class.present?
 
     link = if active_options[:active_disable] === true && is_active_link?(url, active_options[:active])
@@ -44,7 +52,7 @@ module ActiveLinkTo
       link_to(name, url, link_options)
     end
 
-    wrap_tag ? content_tag(wrap_tag, link, :class => (css_class if css_class.present?)) : link
+    wrap_tag ? content_tag(wrap_tag, link, :class => (wrap_class if wrap_class.present?)) : link
   end
 
   # Returns css class name. Takes the link's URL and its params


### PR DESCRIPTION
This allows you to specify classes for the base `a` tag and `wrap_tag` independently. It also sets the `active` class just on the `wrap_tag`.
