### PR TITLE
Add `aria-current="page"` to active links

### DIFF
--- a/lib/active_link_to/active_link_to.rb
+++ b/lib/active_link_to/active_link_to.rb
@@ -37,6 +37,7 @@ module ActiveLinkTo
 
     wrap_tag = active_options[:wrap_tag].present? ? active_options[:wrap_tag] : nil
     link_options[:class] = css_class if css_class.present?
+    link_options["aria-current"] = "page" if is_active_link?(url, active_options[:active])
 
     link = if active_options[:active_disable] === true && is_active_link?(url, active_options[:active])
       content_tag(:span, name, link_options)

--- a/test/active_link_to_test.rb
+++ b/test/active_link_to_test.rb
@@ -194,6 +194,6 @@ class ActiveLinkToTest < MiniTest::Test
   def test_active_link_to_with_url
     request.fullpath = '/root'
     link = active_link_to('label', 'http://example.com/root')
-    assert_html link, 'a.active[href="http://example.com/root"]', 'label'
+    assert_html link, 'a.active[href="http://example.com/root"][aria-current="page"]', 'label'
   end
 end


### PR DESCRIPTION
When a link is active, set the [`aria-current`][w3c] attribute to
[`"page"`][blog].

[w3c]: https://www.w3.org/TR/wai-aria-1.1/#aria-current
[blog]: http://tink.uk/using-the-aria-current-attribute/