### PR TITLE
Use ActionView::Base's on_load hook for monkey-patching

### DIFF
--- a/lib/active_link_to/active_link_to.rb
+++ b/lib/active_link_to/active_link_to.rb
@@ -113,4 +113,6 @@ module ActiveLinkTo
   end
 end
 
-ActionView::Base.send :include, ActiveLinkTo
+ActiveSupport.on_load :action_view do
+  include ActiveLinkTo
+end


### PR DESCRIPTION
Currently, when this gems was bundled to an app, bundler requires lib/active_link_to/active_link_to.rb, then it immediately loads ActionView::Base at the bottom of the file. Hence, the application always loads the whole Action View library and all of its related gems even when not actually using any of view components (e.g. running `rails r`, running test/models/*, etc.)

The attached patch improves this situation by using Action View's handy hook for monkey-patchers, which enables us to postpone the monkey-patch loading until someone actually requires AV/base.