### PR TITLE
Reduce memory allocation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,6 @@
-source 'http://rubygems.org'
+# frozen_string_literal: true
 
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in active_link_to.gemspec
 gemspec
-
-group :test do
-  gem 'minitest'
-  gem 'rake'
-  gem 'rack-test'
-  gem 'nokogiri'
-end

--- a/active_link_to.gemspec
+++ b/active_link_to.gemspec
@@ -1,22 +1,30 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
-$:.unshift File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
 require 'active_link_to/version'
 
 Gem::Specification.new do |s|
-  s.name          = "active_link_to"
+  s.name          = 'active_link_to'
   s.version       = ActiveLinkTo::VERSION
-  s.authors       = ["Oleg Khabarov"]
-  s.email         = ["oleg@khabarov.ca"]
-  s.homepage      = "http://github.com/comfy/active_link_to"
-  s.summary       = "ActionView helper to render currently active links"
-  s.description   = "Helpful method when you need to add some logic that figures out if the link (or more often navigation item) is selected based on the current page or other arbitrary condition"
-  s.license       = "MIT"
+  s.authors       = ['Oleg Khabarov']
+  s.email         = ['oleg@khabarov.ca']
+  s.homepage      = 'http://github.com/comfy/active_link_to'
+  s.summary       = 'ActionView helper to render currently active links'
+  s.description   = 'Helpful method when you need to add some logic that figures out if the link (or more often navigation item) is selected based on the current page or other arbitrary condition'
+  s.license       = 'MIT'
 
-  s.files         = `git ls-files`.split("\n")
+  s.files         = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(test|spec|features)/})
+  end
 
-  s.required_ruby_version = ">= 2.3.0"
+  s.required_ruby_version = '>= 2.3.0'
+  s.add_development_dependency 'minitest'
+  s.add_development_dependency 'nokogiri'
+  s.add_development_dependency 'rack-test'
+  s.add_development_dependency 'rake'
 
-  s.add_dependency 'actionpack'
-  s.add_dependency 'addressable'
+  s.add_dependency 'actionpack', '>= 5.0'
+  s.add_dependency 'activesupport', '>= 5.0'
 end

--- a/lib/active_link_to.rb
+++ b/lib/active_link_to.rb
@@ -1,3 +1,5 @@
-require 'addressable/uri'
+# frozen_string_literal: true
+
+require 'active_support/core_ext/uri'
 require 'active_link_to/active_link_to'
 require 'active_link_to/version'

--- a/lib/active_link_to/active_link_to.rb
+++ b/lib/active_link_to/active_link_to.rb
@@ -1,5 +1,12 @@
-module ActiveLinkTo
+# frozen_string_literal: true
 
+module ActiveLinkTo
+  ACTIVE_OPTIONS = %i[active
+                      class_active
+                      class_inactive
+                      active_disable
+                      wrap_tag
+                      wrap_class].freeze
   # Wrapper around link_to. Accepts following params:
   #   :active         => Boolean | Symbol | Regex | Controller/Action Pair
   #   :class_active   => String
@@ -9,46 +16,47 @@ module ActiveLinkTo
   # Example usage:
   #   active_link_to('/users', class_active: 'enabled')
   #   active_link_to(users_path, active: :exclusive, wrap_tag: :li)
-  def active_link_to(*args, &block)
-    name = block_given? ? capture(&block) : args.shift
-    options = args.shift || {}
-    html_options = args.shift || {}
-    
-    url = url_for(options)
-
-    active_options  = { }
-    link_options    = { }
+  def active_link_to(name = nil, options = nil, html_options = nil, &block)
+    if block_given?
+      html_options = options
+      options = name
+      name = capture(&block)
+    end
+    options ||= {}
+    html_options ||= {}
+    active_options = {}
+    link_options = {}
     html_options.each do |k, v|
-      if [:active, :class_active, :class_inactive, :active_disable, :wrap_tag, :wrap_class].member?(k)
+      if ACTIVE_OPTIONS.include?(k)
         active_options[k] = v
       else
         link_options[k] = v
       end
     end
 
-    css_class = link_options.delete(:class).to_s + ' '
+    url = url_for(options)
 
-    wrap_tag    = active_options[:wrap_tag].present? ? active_options[:wrap_tag] : nil
-    wrap_class  = active_options[:wrap_class].present? ? active_options[:wrap_class] + ' ' : ''
+    css_class = link_options.delete(:class)
+    wrap_tag  = active_options[:wrap_tag]
 
+    active = is_active_link?(url, active_options[:active])
+    active_class = active_link_to_class(url, active_options)
+    link_options['aria-current'] ||= 'page' if active
+    link_options[:class] = "#{css_class} #{active_class}".strip
+
+    link = if active_options[:active_disable] == true && active
+             content_tag(:span, name, link_options)
+           else
+             link_to(name, url, link_options)
+           end
     if wrap_tag.present?
-      wrap_class << active_link_to_class(url, active_options)
-      wrap_class.strip!
+      wrap_html_options = {
+        class: "#{active_options[:wrap_class]} #{active_class}".strip
+      }
+      content_tag(wrap_tag, link, wrap_html_options)
     else
-      css_class << active_link_to_class(url, active_options)
-      css_class.strip!
+      link
     end
-
-    link_options[:class] = css_class if css_class.present?
-    link_options['aria-current'] = 'page' if is_active_link?(url, active_options[:active])
-
-    link = if active_options[:active_disable] === true && is_active_link?(url, active_options[:active])
-      content_tag(:span, name, link_options)
-    else
-      link_to(name, url, link_options)
-    end
-
-    wrap_tag ? content_tag(wrap_tag, link, class: (wrap_class if wrap_class.present?)) : link
   end
 
   # Returns css class name. Takes the link's URL and its params
@@ -59,7 +67,7 @@ module ActiveLinkTo
     if is_active_link?(url, options[:active])
       options[:class_active] || 'active'
     else
-      options[:class_inactive] || ''
+      options[:class_inactive].to_s
     end
   end
 
@@ -80,30 +88,31 @@ module ActiveLinkTo
   def is_active_link?(url, condition = nil)
     @is_active_link ||= {}
     @is_active_link[[url, condition]] ||= begin
-      original_url = url
-      url = Addressable::URI::parse(url).path
-      path = request.original_fullpath
       case condition
-      when :inclusive, nil
-        !path.match(/^#{Regexp.escape(url).chomp('/')}(\/.*|\?.*)?$/).blank?
-      when :exclusive
-        !path.match(/^#{Regexp.escape(url)}\/?(\?.*)?$/).blank?
+      when :exclusive, :inclusive, nil
+        url_path = url.split('#').first.split('?').first
+        url_string = URI.parser.unescape(url_path).force_encoding(Encoding::BINARY)
+        request_uri = URI.parser.unescape(request.path).force_encoding(Encoding::BINARY)
+        if condition == :exclusive
+          url_string == request_uri
+        else
+          closing = url_string.end_with?('/') ? '' : '/'
+          url_string == request_uri || request_uri.start_with?(url_string + closing)
+        end
       when :exact
-        path == original_url
+        request.original_fullpath == url
       when Regexp
-        !path.match(condition).blank?
+        request.original_fullpath.match(condition).present?
       when Array
         controllers = [*condition[0]]
         actions     = [*condition[1]]
         (controllers.blank? || controllers.member?(params[:controller])) &&
-        (actions.blank? || actions.member?(params[:action])) ||
-        controllers.any? do |controller, action|
-          params[:controller] == controller.to_s && params[:action] == action.to_s
-        end
-      when TrueClass
-        true
-      when FalseClass
-        false
+          (actions.blank? || actions.member?(params[:action])) ||
+          controllers.any? do |controller, action|
+            params[:controller] == controller.to_s && params[:action] == action.to_s
+          end
+      when TrueClass, FalseClass
+        condition
       when Hash
         condition.all? do |key, value|
           params[key].to_s == value.to_s

--- a/lib/active_link_to/version.rb
+++ b/lib/active_link_to/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActiveLinkTo
-  VERSION = "1.0.5"
+  VERSION = '1.0.5'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,10 @@ class MiniTest::Test
   module FakeRequest
     class Request
       attr_accessor :original_fullpath
+      def path
+        return original_fullpath unless original_fullpath && original_fullpath.include?('?')
+        @path ||= original_fullpath.split('?').first
+      end
     end
     def request
       @request ||= Request.new


### PR DESCRIPTION
Removing addressable reduce a lot the number of object allocated
Taking a more similar approach to Rails `current_page?` method to calculate current path

Some stats from our app with about 5 links using the helper
**Before**
Memory(bytes): **23871**
Objects: **226**
**After**
Memory(bytes): **7960**
Objects: **136**

Some other minor changes to try to improve gem settings