### PR TITLE
Support calls outside of a request

### DIFF
--- a/lib/active_link_to/active_link_to.rb
+++ b/lib/active_link_to/active_link_to.rb
@@ -13,7 +13,7 @@ module ActiveLinkTo
     name = block_given? ? capture(&block) : args.shift
     options = args.shift || {}
     html_options = args.shift || {}
-    
+
     url = url_for(options)
 
     active_options  = { }
@@ -80,6 +80,8 @@ module ActiveLinkTo
   def is_active_link?(url, condition = nil)
     @is_active_link ||= {}
     @is_active_link[[url, condition]] ||= begin
+      return false if request.nil?
+
       original_url = url
       url = Addressable::URI::parse(url).path
       path = request.original_fullpath

--- a/test/active_link_to_test.rb
+++ b/test/active_link_to_test.rb
@@ -1,5 +1,20 @@
 require_relative 'test_helper'
 
+class ActiveLinkToWithoutRequestTest < MiniTest::Test
+  def setup
+    super
+
+    def self.request
+      nil
+    end
+  end
+
+  def test_nil_request
+    refute is_active_link?('/')
+    refute is_active_link?('https://example.com/')
+  end
+end
+
 class ActiveLinkToTest < MiniTest::Test
 
   def test_is_active_link_booleans_test


### PR DESCRIPTION
When rendering from a Rails Mailer, there is not concept of a Request,
so the current implementation fails.

This commit adds an early return for when the `request` is nil.